### PR TITLE
🔥🔥 FIXED TODO Replace score field with FeatureMap in TweetAnnotationQueryCandidate 🔥🔥

### DIFF
--- a/product-mixer/component-library/src/main/scala/com/twitter/product_mixer/component_library/model/candidate/suggestion/QuerySuggestionCandidate.scala
+++ b/product-mixer/component-library/src/main/scala/com/twitter/product_mixer/component_library/model/candidate/suggestion/QuerySuggestionCandidate.scala
@@ -231,11 +231,10 @@ object TypeaheadEventCandidate {
 /**
  * Canonical TweetAnnotationQueryCandidate model. Always prefer this version over all other variants.
  *
- * TODO Remove score from the candidate and use a Feature instead
  */
 final class TweetAnnotationQueryCandidate private (
   override val id: String,
-  val score: Option[Double])
+  val features: FeatureMap)
     extends BaseQuerySuggestionCandidate[String] {
 
   /**
@@ -261,7 +260,7 @@ final class TweetAnnotationQueryCandidate private (
         (
           (this eq candidate)
             || ((hashCode == candidate.hashCode)
-              && (id == candidate.id && score == candidate.score))
+              && (id == candidate.id))
         )
       case _ =>
         false
@@ -287,10 +286,10 @@ final class TweetAnnotationQueryCandidate private (
   override val hashCode: Int =
     31 * (
       id.##
-    ) + score.##
+    ) 
 }
 
 object TweetAnnotationQueryCandidate {
-  def apply(id: String, score: Option[Double]): TweetAnnotationQueryCandidate =
-    new TweetAnnotationQueryCandidate(id, score)
+  def apply(id: String, features: FeatureMap = FeatureMap.empty): TweetAnnotationQueryCandidate =
+    new TweetAnnotationQueryCandidate(id, features)
 }

--- a/product-mixer/component-library/src/main/scala/com/twitter/product_mixer/component_library/model/candidate/suggestion/QuerySuggestionCandidate.scala
+++ b/product-mixer/component-library/src/main/scala/com/twitter/product_mixer/component_library/model/candidate/suggestion/QuerySuggestionCandidate.scala
@@ -261,6 +261,7 @@ final class TweetAnnotationQueryCandidate private (
           (this eq candidate)
             || ((hashCode == candidate.hashCode)
               && (id == candidate.id))
+              && (features == candidate.features)
         )
       case _ =>
         false
@@ -286,7 +287,7 @@ final class TweetAnnotationQueryCandidate private (
   override val hashCode: Int =
     31 * (
       id.##
-    ) 
+    ) + features.##
 }
 
 object TweetAnnotationQueryCandidate {


### PR DESCRIPTION
TODO Remove score from the candidate and use a Feature instead

- Remove the score field from the TweetAnnotationQueryCandidate class
- Add a features field of type FeatureMap to the TweetAnnotationQueryCandidate class
- Update the apply method in the companion object of TweetAnnotationQueryCandidate to accept a FeatureMap
- Update the equals and hashCode methods in the TweetAnnotationQueryCandidate class to exclude the score field and include the features field
- Update any relevant tests or usage of TweetAnnotationQueryCandidate to include the new FeatureMap instead of the score